### PR TITLE
config(dhall): add parameter 'generator' to CorrelationID plugin

### DIFF
--- a/dhall/server/service/plugin/Config.dhall
+++ b/dhall/server/service/plugin/Config.dhall
@@ -1,5 +1,5 @@
 < CorrelationId :
-	{ header_name : Text, echo_downstream : Bool }
+	{ header_name : Text, echo_downstream : Bool, generator : Text }
 | RequestTransformer :
 	{ add : { headers : List Text } }
 | RequestTermination :

--- a/dhall/server/service/plugin/CorrelationId.dhall
+++ b/dhall/server/service/plugin/CorrelationId.dhall
@@ -2,10 +2,22 @@ let Plugin = ./Plugin.dhall
 
 let config = ./Config.dhall
 
-in    { name =
-		  "correlation-id"
-	  , config =
-		  config.CorrelationId
-		  { header_name = "X-correl", echo_downstream = True }
-	  }
-	: Plugin
+in    λ(generator : Optional Text)
+	→   { name =
+			"correlation-id"
+		, config =
+			config.CorrelationId
+			{ header_name =
+				"X-correl"
+			, echo_downstream =
+				True
+			, generator =
+				Optional/fold
+				Text
+				generator
+				Text
+				(λ(t : Text) → t)
+				"uuid#counter"
+			}
+		}
+	  : Plugin


### PR DESCRIPTION
This PR adds possibility to define a custom `generator` to use in the
CorrelationID plugin.

The default value ("uuid#counter") is taken from Kong directly
https://docs.konghq.com/hub/kong-inc/correlation-id/#parameters