### PR TITLE
dhall: BREAKING CHANGE update dhall config for 1.33+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
   # Install ansible
   - nix-env -i python3 ansible ansible-lint
-  - nix-env -if ./dhall-1.26.1.nix
+  - nix-env -if ./dhall-1.34.0.nix
 
   # Check ansible version
   - ansible --version

--- a/dhall-1.34.0.nix
+++ b/dhall-1.34.0.nix
@@ -19,4 +19,4 @@ let
         '';
       };
 in
-  mkVersion "1.26.1" "0sl4r3mfairgd6kn26hs1r1lkh8rn992grd73078rhqf5w90ag05"
+  mkVersion "1.34.0" "0n64jkgbv7a3cmlv3gxpgc11p9b5w0k9nc0zm9am2pzmp6vm6b4n"

--- a/dhall/server/service/plugin/correlationId.dhall
+++ b/dhall/server/service/plugin/correlationId.dhall
@@ -2,22 +2,16 @@ let Plugin = ./Plugin.dhall
 
 let config = ./Config.dhall
 
-in    λ(generator : Optional Text)
-    →   { name =
-            "correlation-id"
+in  λ(generator : Optional Text) →
+        { name = "correlation-id"
         , config =
             config.CorrelationId
-            { header_name =
-                "X-correl"
-            , echo_downstream =
-                True
-            , generator =
-                Optional/fold
-                Text
-                generator
-                Text
-                (λ(t : Text) → t)
-                "uuid#counter"
-            }
+              { header_name = "X-correl"
+              , echo_downstream = True
+              , generator =
+                  merge
+                    { None = "uuid#counter", Some = λ(x : Text) → x }
+                    generator
+              }
         }
       : Plugin


### PR DESCRIPTION
Since dhall 1.33.0 lang version the `Optional/fold` function is
removed from the language and can be replaced by the usage of the
`merge` function which now works on Optional values tada since 1.29.

dhall-lang/dhall-haskell#1608

This new code is thus not compatible with versions of dhall
<1.29.0 (due to the new feature of the `merge` function).