### PR TITLE
dhall(plugins): add binding for the 'response-transformer' plugin

### DIFF
--- a/dhall/server/service/plugin/Config.dhall
+++ b/dhall/server/service/plugin/Config.dhall
@@ -1,6 +1,7 @@
 < CorrelationId :
     { header_name : Text, echo_downstream : Bool, generator : Text }
 | RequestTransformer : { add : { headers : List Text } }
+| ResponseTransformer : { add : { headers : List Text } }
 | RequestTermination :
     { status_code : Natural, content_type : Text, body : Text }
 | IPRestriction : { whitelist : Text }

--- a/dhall/server/service/plugin/functions.dhall
+++ b/dhall/server/service/plugin/functions.dhall
@@ -1,5 +1,6 @@
 { mkRequestTermination = ./mkRequestTermination.dhall
 , mkRequestTransformer = ./mkRequestTransformer.dhall
+, mkResponseTransformer = ./mkResponseTransformer.dhall
 , mkIPRestriction = ./mkIPRestriction.dhall
 , correlationId = ./correlationId.dhall
 , mkPreFunction = ./mkPreFunction.dhall

--- a/dhall/server/service/plugin/mkResponseTransformer.dhall
+++ b/dhall/server/service/plugin/mkResponseTransformer.dhall
@@ -1,0 +1,9 @@
+let Plugin = ./Plugin.dhall
+
+let config = ./Config.dhall
+
+in  λ(header : Text) →
+        { name = "response-transformer"
+        , config = config.ResponseTransformer { add.headers = [ header ] }
+        }
+      : Plugin


### PR DESCRIPTION
This plugin is very similar to the existing request-transformer
plugin.

We can expose a Dhall helper to generate this plugin configuration as
the other plugins.