### PR TITLE
travis: Use encrypted token for slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 ---
 language: nix
-nix: 2.3.1
+nix: 2.3.4
+env:
+  - CUSTOM_NIX_PATH=nixpkgs=channel:nixos-20.09
 
-
-# Use the new container infrastructure
-sudo: false
+# Travis nix integration will install nix AFTER the environment variables are set
+# and the nix installer will overide NIX_PATH variable thus we need to re-export it
+before_install:
+  - export NIX_PATH="$CUSTOM_NIX_PATH"
 
 install:
-  # Update nix channels
-  - nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs
-  - nix-channel --remove nixpkgs-unstable
-  - nix-channel --update
-
-  # Install ansible
-  - nix-env -i python3 ansible ansible-lint
-  - nix-env -if ./dhall-1.34.0.nix
+  # Install dependencies
+  - nix-env -i -f ./default.nix
 
   # Check ansible version
   - ansible --version

--- a/custom.nix
+++ b/custom.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }: with pkgs;
 
 let
-  mkVersion =
+  mkDhallVersion =
     version: sha256:
       stdenv.mkDerivation {
         name = "dhall-${version}";
@@ -19,4 +19,6 @@ let
         '';
       };
 in
-  mkVersion "1.34.0" "0n64jkgbv7a3cmlv3gxpgc11p9b5w0k9nc0zm9am2pzmp6vm6b4n"
+{
+  dhall = mkDhallVersion "1.34.0" "0n64jkgbv7a3cmlv3gxpgc11p9b5w0k9nc0zm9am2pzmp6vm6b4n";
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {} }: with pkgs;
+
+  let
+    custom = callPackage ./custom.nix {};
+  in
+{
+  inherit ansible_2_8;
+  inherit (custom)dhall;
+  inherit (python38Packages)
+          ansible-lint;
+}

--- a/tests/kong.py
+++ b/tests/kong.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from http.server import HTTPServer, CGIHTTPRequestHandler
 


### PR DESCRIPTION
This commit adds a notification on slack for travis builds. The token
is encrypted using the repository key with the `travis` CLI:

```
travis encrypt "<user>:<token>" --add notifications.slack.rooms
```

cf documentation
https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications